### PR TITLE
Treat sequences that reached a timeout as failing sequences rather than

### DIFF
--- a/src/org/konveyor/tackle/testgen/core/executor/SequenceExecutor.java
+++ b/src/org/konveyor/tackle/testgen/core/executor/SequenceExecutor.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 import javax.json.Json;
@@ -67,7 +68,6 @@ import org.konveyor.tackle.testgen.util.TackleTestLogger;
 
 import com.github.javaparser.utils.ClassUtils;
 
-import java.util.concurrent.TimeoutException;
 import randoop.ExceptionalExecution;
 import randoop.ExecutionOutcome;
 import randoop.ExecutionVisitor;
@@ -402,6 +402,11 @@ public class SequenceExecutor {
 		} catch (InterruptedException | ExecutionException | TimeoutException e) {
 			future.cancel(true);
 			executorService.shutdownNow();
+			if (e instanceof TimeoutException) {
+				SequenceResults results = new SequenceResults(randoopSequence.size());
+				results.passed = false;
+				return results;
+			}
 			// Identify the cause of the ExecutionException
 			Throwable cause = e.getCause() != null? e.getCause() : e;			
 			throw new RuntimeException(cause);


### PR DESCRIPTION
exception sequences, to enable running them with EvoSuite JEE support.

## Description

Treat sequences that reached a timeout as failing sequences rather than exception sequences, to enable running them with EvoSuite JEE support.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
