### PR TITLE
Null assignment for non-instantiable parameter types

### DIFF
--- a/src/org/konveyor/tackle/testgen/core/executor/JUnitExecutor.java
+++ b/src/org/konveyor/tackle/testgen/core/executor/JUnitExecutor.java
@@ -93,6 +93,7 @@ public class JUnitExecutor {
                         methodCovInfo.put(testPlanRowId, Constants.TestPlanRowCoverage.COVERED_JEE);
                         extSummary.covTestPlanRows__full_jee++;
                     }
+                    extSummary.uncovTestPlanRows__execFail--;
                 }
             } catch (IOException e) {
                 logger.warning(

--- a/src/org/konveyor/tackle/testgen/core/extender/ExtenderSummary.java
+++ b/src/org/konveyor/tackle/testgen/core/extender/ExtenderSummary.java
@@ -37,7 +37,7 @@ public class ExtenderSummary {
     public int covTestPlanRows__partial_jee = 0;
     int covTestPlanRows__initSeq = 0;
     int uncovTestPlanRows__noInitSeq = 0;
-    int uncovTestPlanRows__execFail = 0;
+    public int uncovTestPlanRows__execFail = 0;
     int uncovTestPlanRows__excp = 0;
     int uncovTestPlanRows__excp__OperationParse = 0;
     int uncovTestPlanRows__excp__randoop__IllegalArgument = 0;
@@ -89,7 +89,6 @@ public class ExtenderSummary {
     void printSummaryInfo(HashMap<String, Sequence> seqIdMap,
                           Map<String, Map<String, Set<String>>> extTestSeq,
                           HashMap<String, SequenceExecutor.SequenceResults> execExtSeq,
-                          Map<String, Map<String, Map<String, Map<String, String>>>> discardedExtSeq,
                           int assertionCount) {
         System.out.println("\n==== Summary of CTD-amplified test generation ===");
         System.out.println(" Total base sequences: " + this.sequencePool.totalBaseSequences);
@@ -104,9 +103,7 @@ public class ExtenderSummary {
         System.out.println(" Executed extended sequences: " + execExtSeq.keySet().size());
         System.out.println(" Final extended sequences: " + extTestSeq.values().stream()
             .flatMap(clseq -> clseq.values().stream()).mapToInt(seql -> seql.size()).sum());
-        System.out.println(" Total failing sequences: " + discardedExtSeq.values().stream()
-            .flatMap(clseq -> clseq.values().stream()).flatMap(metseq -> metseq.values().stream())
-            .flatMap(rowseq -> rowseq.values().stream()).count());
+        System.out.println(" Total failing sequences: " + this.uncovTestPlanRows__execFail);
         System.out.println(" Diff assertions added: "+assertionCount);
         System.out.println(" Total test plan rows: " + this.totalTestPlanRows);
         System.out.println(" Covered test plan rows (full): " + this.covTestPlanRows__full);
@@ -152,7 +149,6 @@ public class ExtenderSummary {
     void writeSummaryFile(String appName, HashMap<String, Sequence> seqIdMap,
                           Map<String, Map<String, Set<String>>> extTestSeq,
                           HashMap<String, SequenceExecutor.SequenceResults> execExtSeq,
-                          Map<String, Map<String, Map<String, Map<String, String>>>> discardedExtSeq,
                           int assertionCount)
         throws FileNotFoundException {
         JsonObjectBuilder summaryJson = Json.createObjectBuilder();
@@ -172,11 +168,7 @@ public class ExtenderSummary {
         JsonObjectBuilder extSeqInfo = Json.createObjectBuilder();
         extSeqInfo.add("generated_sequences", seqIdMap.keySet().size());
         extSeqInfo.add("executed_sequences", execExtSeq.keySet().size());
-        extSeqInfo.add("failing_sequences", discardedExtSeq.values().stream()
-            .flatMap(clseq -> clseq.values().stream())
-            .flatMap(metseq -> metseq.values().stream())
-            .flatMap(rowseq -> rowseq.values().stream())
-            .count());
+        extSeqInfo.add("failing_sequences", this.uncovTestPlanRows__execFail);
         extSeqInfo.add("final_sequences", extTestSeq.values().stream()
             .flatMap(clseq -> clseq.values().stream())
             .mapToInt(seql -> seql.size())


### PR DESCRIPTION
## Description

Updated constructor sequence generation to create null assignments for non-instantiable target method parameter types (interface, abstract class, or non-public class).

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested locally using CI test cases and additional test apps.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
