### PR TITLE
Fixes in handling of generic classes during constructor sequence generation

### DIFF
--- a/src/org/konveyor/tackle/testgen/core/extender/TestSequenceExtender.java
+++ b/src/org/konveyor/tackle/testgen/core/extender/TestSequenceExtender.java
@@ -1028,7 +1028,7 @@ public class TestSequenceExtender {
 			} else {
 				// attempt to create a new sequence for instantiating this type
 				try {
-					typeInstSeq = ConstructorSequenceGenerator.createConstructorSequence(typeName, true,
+					typeInstSeq = ConstructorSequenceGenerator.createConstructorSequence(typeName, null,true,
                         this.sequencePool, 0);
 				} catch (ClassNotFoundException | NoSuchMethodException cnfe) {
 					logger.warning("Error creating constructor sequence for " + typeName + ": " + cnfe);
@@ -1548,7 +1548,12 @@ public class TestSequenceExtender {
 		logger.info("Augmenting class sequence pool for constructor sequences for: " + testPlanClasses);
 		for (String clsName : testPlanClasses) {
 			try {
-				ConstructorSequenceGenerator.createConstructorSequence(clsName, false, this.sequencePool, 0);
+			    // skip generic class types
+			    Type clsType = Type.forName(clsName);
+			    if (clsType instanceof GenericClassType) {
+			        continue;
+                }
+				ConstructorSequenceGenerator.createConstructorSequence(clsName, null,false, this.sequencePool, 0);
 			} catch (ClassNotFoundException | NoClassDefFoundError | OperationParseException | NoSuchMethodException cnfe) {
                 logger.warning("Error creating constructor sequence for " + clsName + ": " + cnfe.getMessage());
                 this.extSummary.classNotFoundTypes.add(cnfe.getMessage());


### PR DESCRIPTION
## Description

This PR contains fixes in handling of generic classes during constructor sequence generation:
1. For generic types, keep track of their instantiated types as defined in a constructor parameter and use that to perform type substitution in the constructor call operation 
2. Avoid creating constructor sequences for generic types during initial sequence pool augmented; sequences for such type should be created in the context of an instantiated type (defined as a method/constructor formal parameter)

Related to # (experiment issues)

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested locally using failing apps from the experiment benchmark

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
