### PR TITLE
Fix for NPE on clickables spec

### DIFF
--- a/.github/workflows/ui_testgen_ci.yml
+++ b/.github/workflows/ui_testgen_ci.yml
@@ -38,11 +38,11 @@ jobs:
         servers: '[
           {"id": "github-sinha108", "username": "$GITHUB_ACTOR", "password": "${{ secrets.TKLTEST_PKGS_PAT }}"}
         ]'
-    - name: Run crawljax config test case on sample data
+    - name: Run crawljax config test cases on sample data
       run: |
         cd tackle-test-generator-ui
         mvn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
-          --batch-mode test -Dtest=CrawljaxRunnerTest#testCreateCrawljaxConfigurationSample
+          --batch-mode test -Dtest=CrawljaxRunnerTest#test*Sample
     - name: Pull test webapps
       run: |
         git submodule init

--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
@@ -220,31 +220,34 @@ public class CrawljaxRunner {
     }
 
     /**
-     * Reads the clickables specifination from the given toml file, and updates crawl rules in
+     * Reads the clickables specification from the given parsed dpec, and updates crawl rules in
      * the given Crawljax configuration builder with included and excluded web elements to be
      * crawled.
-     * @param clickablesSpecFile
+     * @param clickableSpec
      * @param builder
-     * @throws IOException
      */
-    private static void updateClickablesConfiguration(String clickablesSpecFile,
-                                                      CrawljaxConfiguration.CrawljaxConfigurationBuilder builder) throws IOException {
-        TomlParseResult clickableSpec = Toml.parse(Paths.get(clickablesSpecFile));
+    public static void updateClickablesConfiguration(TomlParseResult clickableSpec,
+                                                     CrawljaxConfiguration.CrawljaxConfigurationBuilder builder) {
+//        TomlParseResult clickableSpec = Toml.parse(Paths.get(clickablesSpecFile));
 
         // process click spec
-        TomlTable[] clickElementSpec = clickableSpec.getArray("click.element")
-            .toList()
-            .toArray(new TomlTable[0]);
-        logger.info("adding click element spec for " + clickElementSpec.length + " elements");
-        handleClickablesElementSpec(clickElementSpec, false, builder);
+        if (clickableSpec.contains("click.element")) {
+            TomlTable[] clickElementSpec = clickableSpec.getArray("click.element")
+                .toList()
+                .toArray(new TomlTable[0]);
+            logger.info("adding click element spec for " + clickElementSpec.length + " elements");
+            handleClickablesElementSpec(clickElementSpec, false, builder);
+        }
 
         // process don't click element spec
-        TomlTable[] dontclickElementSpec = clickableSpec.getArray("dont_click.element")
-            .toList()
-            .toArray(new TomlTable[0]);
-        logger.info("adding don't click element spec for " + dontclickElementSpec.length + " elements");
-        handleClickablesElementSpec(dontclickElementSpec, true, builder);
-        logger.info("Done processing click/dont_click.element spec");
+        if (clickableSpec.contains("dont_click.element")) {
+            TomlTable[] dontclickElementSpec = clickableSpec.getArray("dont_click.element")
+                .toList()
+                .toArray(new TomlTable[0]);
+            logger.info("adding don't click element spec for " + dontclickElementSpec.length + " elements");
+            handleClickablesElementSpec(dontclickElementSpec, true, builder);
+            logger.info("Done processing click/dont_click.element spec");
+        }
 
         // process don't click children_of spec
 //        TomlTable[] dontclickChildrenofSpec = clickableSpec.getArray("dont_click.children_of")
@@ -423,7 +426,7 @@ public class CrawljaxRunner {
      * @return
      */
     public static CrawljaxConfiguration createCrawljaxConfiguration(String appUrl, String testDir,
-                                                                     TomlTable generateOptions)
+                                                                    TomlTable generateOptions)
         throws IOException {
         CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(appUrl);
 
@@ -445,7 +448,7 @@ public class CrawljaxRunner {
         else {
             builder.setMaximumStates(maxStates);
         }
-        
+
         // set max explore action
         int maxExploreAction = getIntTypeOption(generateOptions, "max_explore_action");
         if (maxExploreAction > 1) {
@@ -499,7 +502,7 @@ public class CrawljaxRunner {
         // set click and don't-click rules
         String clickablesSpecFile = generateOptions.getString("clickables_spec_file");
         if (clickablesSpecFile != null && !clickablesSpecFile.isEmpty()) {
-            updateClickablesConfiguration(clickablesSpecFile, builder);
+            updateClickablesConfiguration(Toml.parse(Paths.get(clickablesSpecFile)), builder);
         }
 
         // set form input specification

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -55,6 +55,50 @@ public class CrawljaxRunnerTest {
     }
 
     @Test
+    public void testUpdateClickablesConfiguration() {
+        String newLine = System.getProperty("line.separator");
+        String clickablesSpec = String.join(newLine,
+            "[[click.element]]", "  tag_name = \"div\"",
+            "[[dont_click.element]]", "  tag_name = \"a\"",
+            "[[dont_click.element]]", "  tag_name = \"tag1\"", "  with_text = \"some text\""
+        );
+        CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+        CrawlRules crawlRules = builder.build().getCrawlRules();
+        Assert.assertEquals(1, crawlRules.getPreCrawlConfig().getIncludedElements().size());
+        Assert.assertEquals(2, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+
+        // click specified, dont_click not specified
+        clickablesSpec = String.join(newLine,
+            "[[click.element]]", "  tag_name = \"div\""
+        );
+        builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+        crawlRules = builder.build().getCrawlRules();
+        Assert.assertEquals(1, crawlRules.getPreCrawlConfig().getIncludedElements().size());
+        Assert.assertEquals(0, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+
+        // dont_click specified, click not specified
+        clickablesSpec = String.join(newLine,
+            "[[dont_click.element]]", "  tag_name = \"a\""
+        );
+        builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+        crawlRules = builder.build().getCrawlRules();
+        Assert.assertEquals(4, crawlRules.getPreCrawlConfig().getIncludedElements().size());
+        Assert.assertEquals(1, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+
+        // neither click nor dont_click specified
+        clickablesSpec = "";
+        builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+        crawlRules = builder.build().getCrawlRules();
+        Assert.assertEquals(4, crawlRules.getPreCrawlConfig().getIncludedElements().size());
+        Assert.assertEquals(0, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+
+    }
+
+    @Test
     public void testCrawljaxRunnerPetclinic() throws IOException, URISyntaxException {
         String configFile = "./test/data/petclinic/tkltest_ui_config.toml";
         String[] args = {

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -55,7 +55,7 @@ public class CrawljaxRunnerTest {
     }
 
     @Test
-    public void testUpdateClickablesConfiguration() {
+    public void testUpdateClickablesConfigurationSample() {
         String newLine = System.getProperty("line.separator");
         String clickablesSpec = String.join(newLine,
             "[[click.element]]", "  tag_name = \"div\"",


### PR DESCRIPTION
## Description

This PR contains fix for NPE on clickables spec that is missing the click or dont_click element specs and test case for that scenario

Related to #134 

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Added new test case covering different clickables spec scenarios

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
