### PR TITLE
Support tag_name as list in clickables spec

### DIFF
--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
@@ -177,6 +177,10 @@ public class CrawljaxRunner {
     private static void handleClickablesElementSpec(TomlTable[] clickablesElemSpec, boolean dontClick,
                                                     CrawljaxConfiguration.CrawljaxConfigurationBuilder builder) {
         for (TomlTable elem : clickablesElemSpec) {
+            if (!elem.contains("tag_name")) {
+                throw new RuntimeException("Invalid " + (dontClick ? "dont_click" : "click") +
+                    " specification: \"tag_name\" must be provided as a string or list of strings");
+            }
             List<String> tags = new ArrayList<>();
             try {
                 // parse tag_name as a string

--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
@@ -178,9 +178,16 @@ public class CrawljaxRunner {
                                                     CrawljaxConfiguration.CrawljaxConfigurationBuilder builder) {
         for (TomlTable elem : clickablesElemSpec) {
             List<String> tags = new ArrayList<>();
-            TomlArray tagList = elem.getArray("tag_name");
-            for (int i = 0; i < elem.getArray("tag_name").size(); i++) {
-                tags.add(tagList.getString(i));
+            try {
+                // parse tag_name as a string
+                tags.add(elem.getString("tag_name"));
+            }
+            catch (TomlInvalidTypeException e) {
+                // if type error occurs, parse tag_name as an array
+                TomlArray tagList = elem.getArray("tag_name");
+                for (int i = 0; i < elem.getArray("tag_name").size(); i++) {
+                    tags.add(tagList.getString(i));
+                }
             }
             if (elem.contains("with_text")) {
                 String withText = elem.getString("with_text");

--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
@@ -22,10 +22,7 @@ import com.crawljax.stateabstractions.dom.RTEDStateVertexFactory;
 import com.crawljax.stateabstractions.hybrid.HybridStateVertexFactory;
 import org.apache.commons.cli.*;
 import org.konveyor.tackletest.ui.util.TackleTestLogger;
-import org.tomlj.Toml;
-import org.tomlj.TomlParseError;
-import org.tomlj.TomlParseResult;
-import org.tomlj.TomlTable;
+import org.tomlj.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +31,8 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -178,42 +177,64 @@ public class CrawljaxRunner {
     private static void handleClickablesElementSpec(TomlTable[] clickablesElemSpec, boolean dontClick,
                                                     CrawljaxConfiguration.CrawljaxConfigurationBuilder builder) {
         for (TomlTable elem : clickablesElemSpec) {
-            String tagName = elem.getString("tag_name");
+            List<String> tags = new ArrayList<>();
+            TomlArray tagList = elem.getArray("tag_name");
+            for (int i = 0; i < elem.getArray("tag_name").size(); i++) {
+                tags.add(tagList.getString(i));
+            }
             if (elem.contains("with_text")) {
                 String withText = elem.getString("with_text");
                 if (withText != null && !withText.isEmpty()) {
                     if (dontClick) {
-                        builder.crawlRules().dontClick(tagName).withText(withText);
+                        for (String tag: tags) {
+                            builder.crawlRules().dontClick(tag).withText(withText);
+                        }
                     } else {
-                        builder.crawlRules().click(tagName).withText(withText);
+                        for (String tag: tags) {
+                            builder.crawlRules().click(tag).withText(withText);
+                        }
                     }
                 }
-            } else if (elem.contains("under_xpath")) {
+            }
+            else if (elem.contains("under_xpath")) {
                 String underXpath = elem.getString("under_xpath");
                 if (underXpath != null && !underXpath.isEmpty()) {
                     if (dontClick) {
-                        builder.crawlRules().dontClick(tagName).underXPath(underXpath);
+                        for (String tag: tags) {
+                            builder.crawlRules().dontClick(tag).underXPath(underXpath);
+                        }
                     } else {
-                        builder.crawlRules().click(tagName).underXPath(underXpath);
+                        for (String tag: tags) {
+                            builder.crawlRules().click(tag).underXPath(underXpath);
+                        }
                     }
                 }
-            } else if (elem.contains("with_attribute")) {
+            }
+            else if (elem.contains("with_attribute")) {
                 TomlTable withAttribute = elem.getTable("with_attribute");
                 String attrName = withAttribute.getString("attr_name");
                 String attrValue = withAttribute.getString("attr_value");
                 if (attrName != null && !attrName.isEmpty() && attrValue != null && !attrValue.isEmpty()) {
                     if (dontClick) {
-                        builder.crawlRules().dontClick(tagName).withAttribute(attrName, attrValue);
+                        for (String tag: tags) {
+                            builder.crawlRules().dontClick(tag).withAttribute(attrName, attrValue);
+                        }
                     } else {
-                        builder.crawlRules().click(tagName).withAttribute(attrName, attrValue);
+                        for (String tag: tags) {
+                            builder.crawlRules().click(tag).withAttribute(attrName, attrValue);
+                        }
                     }
                 }
             } else {
                 // no text, attribute, or xpath specified; set click or don't click on the tag
                 if (dontClick) {
-                    builder.crawlRules().dontClick(tagName);
+                    for (String tag: tags) {
+                        builder.crawlRules().dontClick(tag);
+                    }
                 } else {
-                    builder.crawlRules().click(tagName);
+                    for (String tag: tags) {
+                        builder.crawlRules().click(tag);
+                    }
                 }
             }
         }

--- a/tackle-test-generator-ui/test/data/sample/tkltest_ui_clickables_config.toml
+++ b/tackle-test-generator-ui/test/data/sample/tkltest_ui_clickables_config.toml
@@ -3,7 +3,7 @@
 # elements are identified by one or more HTML tags and optionally using attributes, text, or xpath for that tag
 # [[click.element]]
 #   # tag name(s)
-#   tag_name = [""]
+#   tag_name = [""] or ""
 #   # optionally, specify one of the following to refine the set of elements identified by the tag
 #   with_text = ""
 #   under_xpath = ""
@@ -12,7 +12,7 @@
 
 # click all elements with tag "tag1"
 [[click.element]]
-  tag_name = ["tag1"]
+  tag_name = "tag1"
 
 # click div elements with id "is_clickable"
 [[click.element]]
@@ -26,7 +26,7 @@
 
 # click div elements that occur under the matching xpath
 [[click.element]]
-  tag_name = ["div"]
+  tag_name = "div"
   under_xpath = "//*[@id=\"primary-links\"]/li"
 
 ###
@@ -35,7 +35,7 @@
 # add one such entry for each such set of elements
 # [[dont_click.element]]
 #   # tag name(s)
-#   tag_name = [""]
+#   tag_name = [""] or ""
 #   # optionally, specify one of the following to refine the set of elements identified by the tag
 #   with_text = ""
 #   under_xpath = ""
@@ -54,12 +54,12 @@
 
 # do not click button elements with name "Update record..."
 [[dont_click.element]]
-  tag_name = ["button"]
+  tag_name = "button"
   with_attribute = { attr_name = "name", attr_value = "Update record..."}
 
 # do not click anchor elements with text "Upload file"
 [[dont_click.element]]
-  tag_name = ["a"]
+  tag_name = "a"
   with_text = "Upload file"
 
 # do not click div and tag123 elements that occur under the matching xpath

--- a/tackle-test-generator-ui/test/data/sample/tkltest_ui_clickables_config.toml
+++ b/tackle-test-generator-ui/test/data/sample/tkltest_ui_clickables_config.toml
@@ -1,9 +1,9 @@
 ###
 # specification of web elements to click during crawling (on top of the default elements)
-# elements are identified by an HTML tag and optionally using attributes, text, or xpath for that tag
+# elements are identified by one or more HTML tags and optionally using attributes, text, or xpath for that tag
 # [[click.element]]
-#   # tag name
-#   tag_name = ""
+#   # tag name(s)
+#   tag_name = [""]
 #   # optionally, specify one of the following to refine the set of elements identified by the tag
 #   with_text = ""
 #   under_xpath = ""
@@ -12,30 +12,30 @@
 
 # click all elements with tag "tag1"
 [[click.element]]
-  tag_name = "tag1"
+  tag_name = ["tag1"]
 
 # click div elements with id "is_clickable"
 [[click.element]]
-  tag_name = "div"
+  tag_name = ["div"]
   with_attribute = { attr_name = "id", attr_value = "is_clickable"}
 
-# click tag1 elements with text "some text"
+# click tag1 and tag2 elements with text "some text"
 [[click.element]]
-  tag_name = "tag1"
+  tag_name = ["tag1", "tag2"]
   with_text = "some text"
 
 # click div elements that occur under the matching xpath
 [[click.element]]
-  tag_name = "div"
+  tag_name = ["div"]
   under_xpath = "//*[@id=\"primary-links\"]/li"
 
 ###
 # specification of web elements to not click during crawling
-# elements are identified by an HTML tag and optionally using attributes, text, or xpath for that tag
+# elements are identified by one or more HTML tags and optionally using attributes, text, or xpath for that tag
 # add one such entry for each such set of elements
 # [[dont_click.element]]
-#   # tag name
-#   tag_name = ""
+#   # tag name(s)
+#   tag_name = [""]
 #   # optionally, specify one of the following to refine the set of elements identified by the tag
 #   with_text = ""
 #   under_xpath = ""
@@ -45,24 +45,24 @@
 # do not click any anchor element
 # (do not click spec for all occurrences of a tag is unlikely to be used but is supported)
 [[dont_click.element]]
-  tag_name = "a"
+  tag_name = ["a"]
 
 # do not click input elements with id "Delete records"
 [[dont_click.element]]
-  tag_name = "input"
+  tag_name = ["input"]
   with_attribute = { attr_name = "id", attr_value = "Delete records"}
 
 # do not click button elements with name "Update record..."
 [[dont_click.element]]
-  tag_name = "button"
+  tag_name = ["button"]
   with_attribute = { attr_name = "name", attr_value = "Update record..."}
 
 # do not click anchor elements with text "Upload file"
 [[dont_click.element]]
-  tag_name = "a"
+  tag_name = ["a"]
   with_text = "Upload file"
 
-# do not click anchor elements that occur under the matching xpath
+# do not click div and tag123 elements that occur under the matching xpath
 [[dont_click.element]]
-  tag_name = "a"
+  tag_name = ["div", "tag123"]
   under_xpath = "//*[@id=\"primary-links\"]/li"

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -58,9 +58,9 @@ public class CrawljaxRunnerTest {
     public void testUpdateClickablesConfigurationSample() {
         String newLine = System.getProperty("line.separator");
         String clickablesSpec = String.join(newLine,
-            "[[click.element]]", "  tag_name = \"div\"",
-            "[[dont_click.element]]", "  tag_name = \"a\"",
-            "[[dont_click.element]]", "  tag_name = \"tag1\"", "  with_text = \"some text\""
+            "[[click.element]]", "  tag_name = [\"div\"]",
+            "[[dont_click.element]]", "  tag_name = [\"a\"]",
+            "[[dont_click.element]]", "  tag_name = [\"tag1\"]", "  with_text = \"some text\""
         );
         CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
         CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
@@ -70,7 +70,7 @@ public class CrawljaxRunnerTest {
 
         // click specified, dont_click not specified
         clickablesSpec = String.join(newLine,
-            "[[click.element]]", "  tag_name = \"div\""
+            "[[click.element]]", "  tag_name = [\"div\"]"
         );
         builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
         CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
@@ -80,7 +80,7 @@ public class CrawljaxRunnerTest {
 
         // dont_click specified, click not specified
         clickablesSpec = String.join(newLine,
-            "[[dont_click.element]]", "  tag_name = \"a\""
+            "[[dont_click.element]]", "  tag_name = [\"a\"]"
         );
         builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
         CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -48,8 +48,8 @@ public class CrawljaxRunnerTest {
         Assert.assertEquals(2, crawljaxConfig.getCrawlRules().getMaxRepeatExploredActions());
         Assert.assertEquals(2, crawljaxConfig.getMaximumDepth());
         CrawlRules crawlRules = crawljaxConfig.getCrawlRules();
-        Assert.assertEquals(8, crawlRules.getPreCrawlConfig().getIncludedElements().size());
-        Assert.assertEquals(5, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+        Assert.assertEquals(9, crawlRules.getPreCrawlConfig().getIncludedElements().size());
+        Assert.assertEquals(6, crawlRules.getPreCrawlConfig().getExcludedElements().size());
         Assert.assertEquals(500, crawlRules.getWaitAfterEvent());
         Assert.assertEquals(500, crawlRules.getWaitAfterReloadUrl());
     }

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -14,6 +14,7 @@ import com.crawljax.core.configuration.CrawlRules;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
@@ -95,7 +96,32 @@ public class CrawljaxRunnerTest {
         crawlRules = builder.build().getCrawlRules();
         Assert.assertEquals(4, crawlRules.getPreCrawlConfig().getIncludedElements().size());
         Assert.assertEquals(0, crawlRules.getPreCrawlConfig().getExcludedElements().size());
+    }
 
+    @Test
+    public void testUpdateClickablesConfigurationClickSpecExcpSample() {
+        // click spec with no tag_name property
+        final String clickablesSpec = "[[click.element]]";
+        final CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        Assert.assertThrows(RuntimeException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+            }
+        });
+    }
+
+    @Test
+    public void testUpdateClickablesConfigurationDontclickSpecExcpSample() {
+        // dont_click spec with no tag_name property
+        final String clickablesSpec = "[[dont_click.element]]";
+        final CrawljaxConfiguration.CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor("http://localhost:8080");
+        Assert.assertThrows(RuntimeException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                CrawljaxRunner.updateClickablesConfiguration(Toml.parse(clickablesSpec), builder);
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR contains updates in clickables spec processing to support `tag_name` as list of strings or a string.

Related to #135 

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested using updated CI test cases

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
