### PR TITLE
Removed "add_state_diff_assertions" option for tkltest-ui

### DIFF
--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/CrawljaxRunner.java
@@ -551,8 +551,8 @@ public class CrawljaxRunner {
 
         // add crawl-overview and test-generator plugins
         builder.addPlugin(new CrawlOverview());
-        builder.addPlugin(new TestSuiteGenerator(
-            createTestConfiguration(generateOptions.getString("add_state_diff_assertions"))));
+//        builder.addPlugin(new TestSuiteGenerator(
+//            createTestConfiguration(generateOptions.getString("add_state_diff_assertions"))));
 
         // set output directory
         builder.setOutputDirectory(new File(testDir));


### PR DESCRIPTION

## Description

Removed processing of "add_state_diff_assertions" option. This option was removed in the CLI earlier but left in core.
This results in NPE when a configuration without that option is parsed.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
