### PR TITLE
Handle parameterized types with only partial wildcard capture types

### DIFF
--- a/tackle-test-generator-unit/src/org/konveyor/tackle/testgen/core/extender/TestSequenceExtender.java
+++ b/tackle-test-generator-unit/src/org/konveyor/tackle/testgen/core/extender/TestSequenceExtender.java
@@ -683,8 +683,7 @@ public class TestSequenceExtender {
                     methodCovInfo.put(testPlanRowId, Constants.TestPlanRowCoverage.UNCOVERED_EXEC_FAIL);
                     if (badPathSeqs.contains(sequenceID)) {
                     	// sequence execution failed, but it raised a declared exception, so we want to keep it for bad path testing
-                    	this.extSeqStr.put(sequenceID,
-                                extendedSeq.toCodeString().replaceAll("<Capture\\d+(,Capture\\d+)*>", ""));
+                    	this.extSeqStr.put(sequenceID, getCodeString(extendedSeq));
                     }
                     continue;
                 }
@@ -705,8 +704,7 @@ public class TestSequenceExtender {
             // and mark test plan row as covered
             partitionTestSeq.get(qualMethodSig).add(sequenceID);
             methodSeqIds.add(sequenceID);
-            this.extSeqStr.put(sequenceID,
-                extendedSeq.toCodeString().replaceAll("<Capture\\d+(,Capture\\d+)*>", ""));
+            this.extSeqStr.put(sequenceID, getCodeString(extendedSeq));
             if (this.rowPartiallyCovered) {
                 methodCovInfo.put(testPlanRowId, Constants.TestPlanRowCoverage.PARTIAL);
                 this.extSummary.covTestPlanRows__partial++;
@@ -735,6 +733,20 @@ public class TestSequenceExtender {
 
         return methodSeqIds;
     }
+	
+	// returns sequence string ready for use as code after cleaning wildcard capture types
+	
+	private String getCodeString(Sequence seq) {
+		
+		String codeStr = seq.toCodeString().replaceAll("<Capture\\d+(,Capture\\d+)*>", "");
+		
+		// now handle the cases that only beginning/end types are wildcard capture
+		
+		codeStr = codeStr.replaceAll(",Capture\\d+>", ",?>");
+		codeStr = codeStr.replaceAll("<Capture\\d+,", "<?,");
+		
+		return codeStr;
+	}
 
 	// Get method or constructor by its signature
 


### PR DESCRIPTION


## Description

Support the case where only beginning/end of types in a parameterized types are wildcard capture, to enable generating a compilable test from sequences containing such cases.

Related to # (109) in planning repo

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
