### PR TITLE
Precrawl plugin for performing actions before crawling

### DIFF
--- a/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/plugins/TackleTestOnUrlFirstLoadPlugin.java
+++ b/tackle-test-generator-ui/src/org/konveyor/tackletest/ui/crawljax/plugins/TackleTestOnUrlFirstLoadPlugin.java
@@ -1,0 +1,93 @@
+package org.konveyor.tackletest.ui.crawljax.plugins;
+
+import com.crawljax.core.CrawlerContext;
+import com.crawljax.core.plugin.OnUrlFirstLoadPlugin;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.tomlj.TomlTable;
+
+import java.time.Duration;
+
+/**
+ * Plugin class for sequence of actions that execute on first load of the AUT URL prior to
+ * crawling; implemented via Crawljax plugin interface.
+ */
+public class TackleTestOnUrlFirstLoadPlugin implements OnUrlFirstLoadPlugin {
+
+    private TomlTable[] preCrawlActions;
+
+    /**
+     * Construct plugin instance with the specified pre-crawl actions.
+     * @param preCrawlActions
+     */
+    public TackleTestOnUrlFirstLoadPlugin(TomlTable[] preCrawlActions) {
+        this.preCrawlActions = preCrawlActions;
+    }
+
+    /**
+     * Perform pre-crawl actions specified in the clickables spec on first load of URL
+     * @param crawlerContext
+     */
+    @Override
+    public void onUrlFirstLoad(CrawlerContext crawlerContext) {
+        // get web driver instance and driver wait instance with the configired wait-after-event duration
+        WebDriver driver = crawlerContext.getBrowser().getWebDriver();
+        long waitAfterEvent = crawlerContext.getConfig().getCrawlRules().getWaitAfterEvent();
+        WebDriverWait driverWait = new WebDriverWait(driver, Duration.ofMillis(waitAfterEvent));
+
+        // execute specified pre-crawl actions
+        for (TomlTable action : this.preCrawlActions) {
+
+            // compute selenium locator
+            By locator = null;
+            if (action.contains("by_id")) {
+                String elemId = action.getString("by_id");
+                if (!elemId.isEmpty()) {
+                    locator = By.id(elemId);
+                }
+            }
+            else if (action.contains("by_name")) {
+                String elemName = action.getString("by_name");
+                if (!elemName.isEmpty()) {
+                    locator = By.name(elemName);
+                }
+            }
+            else if (action.contains("under_xpath")) {
+                String elemXpath = action.getString("under_xpath");
+                if (!elemXpath.isEmpty()) {
+                    locator = By.xpath(elemXpath);
+                }
+            }
+            else if (action.contains("with_text")) {
+                String elemText = action.getString("with_text");
+                if (!elemText.isEmpty()) {
+                    locator = By.linkText(elemText);
+                }
+            }
+            else if (action.contains("by_css_selector")) {
+                String elemCssSelector = action.getString("by_css_selector");
+                if (!elemCssSelector.isEmpty()) {
+                    locator = By.cssSelector(elemCssSelector);
+                }
+            }
+            // perform the specified action type (click or enter) if locator is non-null
+            String actionType = action.getString("action_type");
+            if (locator != null) {
+                if (actionType.equals("click")) {
+                    driverWait.until(ExpectedConditions.elementToBeClickable(locator)).click();
+                }
+                else if (actionType.equals("enter")) {
+                    driverWait.until(ExpectedConditions.elementToBeClickable(locator))
+                        .sendKeys(action.getString("input_value"));
+                }
+                else {
+                    throw new RuntimeException("Unsupported pre-crawl action type: "+actionType+
+                        "\n  must be one of [click, enter]");
+                }
+            }
+        }
+    }
+
+}

--- a/tackle-test-generator-ui/test/data/petclinic/tkltest_ui_config.toml
+++ b/tackle-test-generator-ui/test/data/petclinic/tkltest_ui_config.toml
@@ -15,6 +15,7 @@ wait_after_event = 500
 wait_after_reload = 500
 clickables_spec_file = ""
 form_data_spec_file = "test/data/petclinic/tkltest_ui_formdata_config.toml"
+precrawl_actions_spec_file = "test/data/petclinic/tkltest_ui_precrawl_actions_config.toml"
 click_once = true
 click_randomly = true
 max_depth = 3

--- a/tackle-test-generator-ui/test/data/petclinic/tkltest_ui_precrawl_actions_config.toml
+++ b/tackle-test-generator-ui/test/data/petclinic/tkltest_ui_precrawl_actions_config.toml
@@ -1,0 +1,24 @@
+###
+# Specification of pre-crawl actions to perform. The specification consists of the following properties
+#   - action_type: type of action to perform (click, enter)
+#   - one of the following element locator properties: by_id, by_name, under_xpath, with_text, by_css_selector
+#   - if action_type is "enter", the following property
+#     - input_value: value to be entered in text box
+###
+
+[[precrawl_action]]
+  action_type = "click"
+  under_xpath = "/html/body/app-root/div[1]/nav/div/ul/li[5]/a/span[2]"
+
+[[precrawl_action]]
+  action_type = "click"
+  under_xpath = "/html/body/app-root/app-specialty-list/div/div/div/button[2]"
+
+[[precrawl_action]]
+  action_type = "enter"
+  under_xpath = "//*[@id=\"name\"]"
+  input_value = "cardiology"
+
+[[precrawl_action]]
+  action_type = "click"
+  under_xpath = "/html/body/app-root/app-specialty-list/div/div/div[2]/button[1]"

--- a/tackle-test-generator-ui/test/data/sample/tkltest_ui_config.toml
+++ b/tackle-test-generator-ui/test/data/sample/tkltest_ui_config.toml
@@ -15,6 +15,7 @@ wait_after_event = 500
 wait_after_reload = 500
 clickables_spec_file = "./test/data/sample/tkltest_ui_clickables_config.toml"
 form_data_spec_file = ""
+precrawl_actions_spec_file = "test/data/sample/tkltest_ui_precrawl_actions_config.toml"
 click_once = true
 click_randomly = true
 max_depth = 2

--- a/tackle-test-generator-ui/test/data/sample/tkltest_ui_precrawl_actions_config.toml
+++ b/tackle-test-generator-ui/test/data/sample/tkltest_ui_precrawl_actions_config.toml
@@ -1,0 +1,28 @@
+###
+# Specification of pre-crawl actions to perform. The specification consists of the following properties
+#   - action_type: type of action to perform (click, enter)
+#   - one of the following element locator properties: by_id, by_name, under_xpath, with_text, by_css_selector
+#   - if action_type is "enter", the following property
+#     - input_value: value to be entered in text box
+###
+
+[[precrawl_action]]
+  action_type = "click"
+  by_id = "id"
+
+[[precrawl_action]]
+  action_type = "click"
+  by_name = "name"
+
+[[precrawl_action]]
+  action_type = "click"
+  under_xpath = "//*[@id=\"primary-links\"]/li"
+
+[[precrawl_action]]
+  action_type = "click"
+  with_text = "Upload file"
+
+[[precrawl_action]]
+  action_type = "enter"
+  by_name = "firstName"
+  input_value = "pipi"

--- a/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
+++ b/tackle-test-generator-ui/test/java/org/konveyor/tackletest/ui/crawljax/CrawljaxRunnerTest.java
@@ -18,9 +18,12 @@ package org.konveyor.tackletest.ui.crawljax;
 
 import com.crawljax.core.configuration.CrawlRules;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.plugin.Plugin;
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
+import org.konveyor.tackletest.ui.crawljax.plugins.TackleTestOnUrlFirstLoadPlugin;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
@@ -61,6 +64,11 @@ public class CrawljaxRunnerTest {
         Assert.assertEquals(6, crawlRules.getPreCrawlConfig().getExcludedElements().size());
         Assert.assertEquals(500, crawlRules.getWaitAfterEvent());
         Assert.assertEquals(500, crawlRules.getWaitAfterReloadUrl());
+
+        // pre-crawl plugin assertions
+        ImmutableList<Plugin> plugins = crawljaxConfig.getPlugins();
+        Assert.assertEquals(4, plugins.size());
+        Assert.assertTrue(plugins.stream().anyMatch(plugin -> plugin instanceof TackleTestOnUrlFirstLoadPlugin));
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR adds the implementation of an "on URL first load" plugin class that performs a sequence of actions on the AUT UI prior to start of crawling.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
